### PR TITLE
Send location URL of the other alternative

### DIFF
--- a/v.php
+++ b/v.php
@@ -14,8 +14,10 @@ $upstat = mysqli_query($db_con, "UPDATE `stats` SET LinkViews = LinkViews + 1 WH
 $d = date('i');
 $d = intval($d);
 if ($d % 2 == 0) {
+	header('FiftyFifty-Alternate-Location: ' . $urls[url2]);
 	header('Location: ' . $urls[url1]);
 }else{
+	header('FiftyFifty-Alternate-Location: ' . $urls[url1]);
 	header('Location: ' . $urls[url2]);
 }
 ?>


### PR DESCRIPTION
This allows users and software to get both URLs without having to reload your site a bunch of times.

The custom header name is in line with the recommendations set forth in RFC 6648.

https://tools.ietf.org/html/rfc6648